### PR TITLE
Fixed link to ibmq notebook

### DIFF
--- a/src/ch12/ch12.ipynb
+++ b/src/ch12/ch12.ipynb
@@ -279,7 +279,7 @@
    "source": [
     "### Running on real quantum hardware (12.2.3)\n",
     "\n",
-    "The code for this section can be found in this [notebook](/ibmq/ibmq_experiments_sampler.ipynb)."
+    "The code for this section can be found in this [notebook](../ibmq/ibmq_experiments_sampler.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
The current link is broken.